### PR TITLE
feat: Добавил спавн шаттлов

### DIFF
--- a/code/__HELPERS/shuttle.dm
+++ b/code/__HELPERS/shuttle.dm
@@ -24,15 +24,10 @@
 	var/delta_width = 0
 	for(var/id in ids)
 		var/datum/map_template/shuttle/our_template = SSmapping.shuttle_templates[id]
-		// We do a standard load here so any errors will properly runtimes
-		var/obj/docking_port/mobile/ship = SSshuttle.action_load(our_template, port)
-		if(ship)
-			ship.jumpToNullSpace()
-			ship = null
 		// Yes this is very hacky, but we need to both allow loading a template that's too big to be an error state
 		// And actually get the sizing information from every shuttle
 		SSshuttle.load_template(our_template)
-		var/obj/docking_port/mobile/theoretical_ship = SSshuttle.preview_shuttle
+		var/obj/docking_port/mobile/theoretical_ship = SSshuttle.action_load(our_template, port)
 		if(theoretical_ship)
 			height = max(theoretical_ship.height, height)
 			width = max(theoretical_ship.width, width)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -290,9 +290,8 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 			SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_PURCHASED
 			for(var/datum/round_event_control/shuttle_insurance/insurance_event in SSevents.control)
 				insurance_event.weight *= 20
-			SSshuttle.unload_preview()
 			SSshuttle.existing_shuttle = SSshuttle.emergency
-			SSshuttle.action_load(shuttle, replace = TRUE)
+			SSshuttle.action_load(shuttle)
 			bank_account.adjust_money(-shuttle.credit_cost)
 
 			var/purchaser_name = (obj_flags & EMAGGED) ? scramble_message_replace_chars("AUTHENTICATION FAILURE: CVE-2018-17107", 60) : user.real_name

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -53,9 +53,8 @@
 		station_balance?.adjust_money(8000)
 		return
 	SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_FORCED
-	SSshuttle.unload_preview()
 	SSshuttle.existing_shuttle = SSshuttle.emergency
-	SSshuttle.action_load(new_shuttle, replace = TRUE)
+	SSshuttle.action_load(new_shuttle)
 	log_shuttle("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")
 
 /datum/event_admin_setup/warn_admin/shuttle_catastrophe

--- a/modular_nova/modules/cryosleep/code/cryopod.dm
+++ b/modular_nova/modules/cryosleep/code/cryopod.dm
@@ -168,6 +168,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	var/quiet = FALSE
 	/// Has the occupant been tucked in?
 	var/tucked = FALSE
+	// Корабль которому принадлежит
+	var/obj/docking_port/mobile/voidcrew/linked_ship
 
 /obj/machinery/cryopod/quiet
 	quiet = TRUE
@@ -187,6 +189,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 /obj/machinery/cryopod/Destroy()
 	GLOB.valid_cryopods -= src
 	control_computer_weakref = null
+	linked_ship?.spawn_points -= src
+	linked_ship = null
 	return ..()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent = FALSE)
@@ -517,6 +521,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cryopod/prison, 18)
 	. = ..()
 	// Flick the pod for a second when user enters
 	flick("prisonpod-open", src)
+
+/obj/machinery/cryopod/connect_to_shuttle(mapload, obj/docking_port/mobile/voidcrew/port, obj/docking_port/stationary/dock)
+	. = ..()
+	linked_ship = port
+	linked_ship.spawn_points += src
 
 // Wake-up notifications
 


### PR DESCRIPTION

## Описание / Что этот PR делает

- Добавляет функционал спавна шаттлов, сначала загружается шаблон на виртуальный з-уровень, если передали порт куда потом его переместить, перемещается туда, иначе просто спавнится в рандомной точке на общей карте.
- Персонаж игрока сразу спавнится на корабле под первой доступной ролью (обычно это капитан), так же имеется возможность заспавниться на корабле под другой ролью.
- Криокапсулам добавлена возможность определять на каком шаттле они находятся и сохраняться как точки спавна игроков.
- На данный момент по-умолчанию на карте и так спавнится один шаттл, на который спавнится игрок прожавший ready до раундстарта, в будущем это поведение изменится, поэтому не менял.
- Убрал функционал "предпросмотра" корабля, как устаревший, в данный момент нигде не используется, если понадобится такая фича, сможем если что добавить отдельно, чтобы не задействовало основной код загрузки шаблонов
## Причина создания ПР / Почему это хорошо для игры
Переносим базовый спавн шипов, будет дорабатываться в будущем, когда появится аванпост, стоит так же подумать о рефакторе подсистемы шаттлов, вынести проки не принадлежащие данному классу.
## Демонстрация изменений / Тестирование
<details>
<summary>Скриншоты/Видео с изменениями</summary>
</details>

## Список изменений

:cl:
add: Добавил возможность спавна корабля
add: Добавил возможность спавна игрока на корабле
del: Удалил функционал "предпросмотра" корабля
/:cl:
## Подтверждение о готовности PR
- [X] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
