### PR TITLE
Шаблон для баг-репортов

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -1,65 +1,46 @@
-name: Bug Report
-description: Create a report to help reproduce and fix the issue.
+name: Отчёт о баге
+description: Сообщите о баге
+title: "[Баг]: "
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        # **Please read the following guidelines. Follow all instructions or else your issue is subject to closure.**
-        ## If you use the "Report Issue" button in the top-right corner of the game, it will automatically fill in some of the information below.
-
-        If you are reporting an issue found in another branch or codebase, you _must_ link the branch or codebase repo in your issue report or it will be closed.
-        For branches, If you have not pushed your code up, please either reproduce it on master or push your code up before making an issue report.
-        For other codebases, if you do not have a public code repository you will be refused help unless you can completely reproduce the issue on our master branch.
+        Спасибо за участие во вкладе в наш проект!
   - type: input
-    id: reporting-version
+    id: contact
     attributes:
-      label: "Client Version:"
-      description: |
-        The BYOND version you are using to report this issue. You can find this information in the bottom left corner of the "About BYOND" window in the BYOND client.
-        It is strongly recommended that you include this, especially for concerns on the visual aspects of the game.
-      placeholder: "xxx.xxxx"
+      label: Укажите ваш сикей
+      placeholder: "JackTrasen228"
     validations:
-      required: false
+      required: true
   - type: textarea
-    id: issue-summary
+    id: what-happened
     attributes:
-      label: "Issue Summary:"
-      description: |
-        Briefly explain your issue in a few plain sentences. You may copy and paste the issue title here if it is suitable.
-      placeholder: |
-        "When I do X, Y happens instead of Z."
-        "X on Y map has Z issue."
+      label: Что произошло?
+      description: Подробно опишите, какая неисправность произошла и особенно то, как её воспроизвести. Какой должен быть ожидаемый результат?
+      placeholder: "Сюда можно писать!"
+      value: "Сюда можно писать!"
     validations:
       required: true
   - type: input
-    id: round-id
+    id: version
     attributes:
-      label: "Round ID:"
-      description: |
-        If you discovered this issue from playing tgstation hosted servers, the Round ID can be found in the Status panel or retrieved from https://statbus.space/
-        The Round ID lets us look up valuable information and logs for the round the bug happened. Leave this blank if there is no round ID.
-      placeholder: "XXXXXX"
-    validations:
-      required: false
-  - type: textarea
-    id: test-merges
-    attributes:
-      label: "Test Merge Information:"
-      description: |
-        If you're certain the issue is to be caused by a test merge [OOC Tab -> Show Server Revision], report it in the pull request's comment section rather than on the tracker.
-        If you're unsure you can refer to the issue number by prefixing said number with #. The issue number can be found beside the title after submission of this form.
-    validations:
-      required: false
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: "Reproduction Steps:"
-      description: |
-        Describe the steps to reproduce the issue in detail. Include any relevant information, such as the map, round type, and any other factors that may be relevant.
-        If it is a runtime-related error, please include the runtime here as that is pertient information. Issues are not for oddities introduced by admin varedits, ensure these occur in normal circumstances.
-      placeholder: |
-        1. Go to the X location
-        2. Do Y action
-        3. Observe Z result
+      label: Версия Byond
+      placeholder: "516.XXXX"
     validations:
       required: true
+  - type: input
+    id: roundid
+    attributes:
+      label: ID раунда и время
+      description: Когда это произошло?
+      placeholder: "ID: 1820, 13:37"
+    validations:
+      required: true
+  - type: textarea
+    id: testmerge
+    attributes:
+      label: Информация о тест-мержах
+      description: Если есть возможность, выпишите информацию о тестмержах раунда сюда. Информацию о нём можно добыть во вкладке OOC > Show Server Revision.
+      placeholder: "Тестмержи писать сюда"


### PR DESCRIPTION
Шаблон по заказу

## Список изменений

:cl:
add: Новый шаблон для баг-репорта
/:cl:
## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
